### PR TITLE
Fix the command line command markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 libglitch makes 8-bit sounds in the spirit of viznut's [“algorithmic symphonies”][1], using a small language not entirely unlike Forth. Included is a small programm reading formulas from the command line. GNU/Linux users may try “./glitter.py glitch_machine!a10k4h1f!aAk5h2ff!aCk3hg!ad3e!p!9fm!a4kl13f!aCk7Fhn | aplay -f u8” for playback.
 
-Using sox, sound can easily be exported into wave files: “./glitter.py `cat tracks/sidekick.glitch` | head -c128000 | sox -c 1 -r 8000 -t u8 - sidekick.wav”.
+Using sox, sound can easily be exported into wave files: `./glitter.py $(cat tracks/sidekick.glitch) | head -c128000 | sox -c 1 -r 8000 -t u8 - sidekick.wav`.
 
 For editing and visual effects, try “./glitched.py [filename]”. Controls are the arrow keys (to move the cursor around), page up / page down (to change the opcode), space (to for no opcode), t (for the counter) and all hexadecimal digit keys (for insertion of the corresponding characters). Symbol keys (plus, minus etc.) may also work.
 


### PR DESCRIPTION
The command line markdown was not proper code highlighting syntax, so I fixed it. I also changed from using backticks to using `$()` which is a bit of a bashism, but it still works with most common shells.
